### PR TITLE
Add "bank helper" userscript

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,11 @@ the comments sign `//` from the start of the line.
    * Until Genotype, VIP status, etc. are known, it discreetly asks the user to navigate to the [character details](https://alpha.taustation.space/) page to collect that information.
    * Note: In progress: Detect relevant character skills (e.g., `Healthcare 2`).
 * Provides simple UI to let the user a) enable/disable stat tracking temporarily, b) copy collected logs to the clipboard, c) clear logs collected so far, and d) remove all session data associated with this userscript.
+
+## Tau Station Bank Helper
+
+`bank_helper.js` implements a single feature, at the "Bank" area only:
+
+Whenever your credits "on hand" are greater than the amount you'd always like to keep at hand, it'll prefill the "deposit" textbox with the excess cash.
+
+Note that this does *not* automatically deposit the credits. It simply fills the box for you.

--- a/bank_helper.js
+++ b/bank_helper.js
@@ -1,0 +1,37 @@
+// ==UserScript==
+// @name         Tau Station Bank Helper
+// @namespace    http://tampermonkey.net/
+// @version      0.1
+// @description  Automatically fill the bank deposit box with your extra cash
+// @author       Marco Fontani <MFONTANI@cpan.org>
+// @match        https://alpha.taustation.space/area/bank*
+// @grant        none
+// ==/UserScript==
+
+// @run-at document-end
+(function() {
+    'use strict';
+
+    // How many credits you ALWAYS want to keep on hand.
+    // Anything above it will be auto-filled for deposit while you're at a bank.
+    var amt_min_credits_on_hand = 2000;
+
+    // How much money in the bank
+    var bank_qsa = document.querySelectorAll('.bank-details-container .dl-container dd.even:nth-of-type(4)');
+    if (typeof(bank_qsa) === 'undefined') {
+        return;
+    }
+    var credits_in_bank = parseFloat(bank_qsa[0].innerHTML.replace(',',''));
+
+    // How much money is on me:
+    var on_me_qsa = document.querySelectorAll('.player-info .credit-container.player-info--amount-container span.amount');
+    if (typeof(on_me_qsa) === 'undefined') {
+        return;
+    }
+    var credits_on_me = parseFloat(on_me_qsa[0].innerHTML.replace(',',''));
+
+    // If you've got too many credits, deposit them!
+    if (credits_on_me > amt_min_credits_on_hand) {
+        document.querySelectorAll('#deposit_amount')[0].value = ( credits_on_me*100 - amt_min_credits_on_hand*100 )/100;
+    }
+})();


### PR DESCRIPTION
`bank_helper.js` implements a single feature, at the "Bank" area only:

Whenever your credits "on hand" are greater than the amount you'd always
like to keep at hand, it'll prefill the "deposit" textbox with the
excess cash.

Note that this does *not* automatically deposit the credits.
It simply fills the box for you.