### PR TITLE
Stop hiding Discreet Work page's new task.

### DIFF
--- a/hide_tasks.js
+++ b/hide_tasks.js
@@ -24,7 +24,7 @@ function taustation_hide_tasks() {
         "Complete the clone center's payroll": 1,
         "Create a premium clone": 1,
     };
-    $("td[data-label='Task']").each(function(i,el){
+    $('div.tab-content-career').find("td[data-label='Task']").each(function(i,el){
         if (visibleTasks[el.innerHTML] != 1) {
             $(el).parent().hide();
         }


### PR DESCRIPTION
While this worked fine on the Career Tasks table, it was also affecting the Discreet Work area's table, hiding the single new task that could be performed.  Adding this selector makes it apply only to the table inside the Career Tasks tab.