### PR TITLE
Create hide_decimals_syndicate_banking.js

### DIFF
--- a/hide_decimals_syndicate_banking.js
+++ b/hide_decimals_syndicate_banking.js
@@ -1,0 +1,20 @@
+// ==UserScript==
+// @name         Hide all decimals in donations amounts at syndicate Banking overview
+// @namespace    http://tampermonkey.net/
+// @version      0.1
+// @author       Dot_sent
+// @match        https://alpha.taustation.space/syndicates
+// @grant        none
+// @require http://code.jquery.com/jquery-3.3.1.min.js
+// ==/UserScript==
+
+function taustation_hide_decimals(){
+    $(".currency-amount").each(function(){
+        var elem = $(this);
+        var str = elem[0].innerHTML;
+        str = str.replace(/\..*/gm, '');
+        elem[0].innerHTML = str;
+    })
+}
+
+$(document).ready(taustation_hide_decimals);


### PR DESCRIPTION
This script will hide all the numbers after decimal points in the list of member donations in the Banking block of Syndicate page.