### PR TITLE
Fix discreet helper - include mission updates

### DIFF
--- a/discreet_helper.js
+++ b/discreet_helper.js
@@ -19,7 +19,7 @@
     'use strict';
     var places;
     function refresh_directions() {
-        if (!$('.narrative-direction').length) {
+        if (!$('.narrative-direction, .mission-updates').length) {
             return;
         }
         if (typeof places === 'undefined') {
@@ -32,7 +32,7 @@
                 }
             });
         }
-        $('.narrative-direction:not([data-discreethelper="done"])').each(function(idx,nd) {
+        $('.narrative-direction:not([data-discreethelper="done"]), .mission-updates').each(function(idx,nd) {
             var text = $(nd).html();
             // "tag" as already looked at
             $(nd).attr('data-discreethelper', 'done');


### PR DESCRIPTION
Discreet helper has been broken for a while since last update to Discreet Work. This commit should add translation of area names to links also for .mission-updates blocks.

@Shad0, could you please test if this version works OK for you?